### PR TITLE
Fix broken download links

### DIFF
--- a/src/content/download/latest.md
+++ b/src/content/download/latest.md
@@ -8,6 +8,6 @@ This is a patch release to fix a few issues with 2.15.4. All users should upgrad
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4p1/7kaa-install-win32-2.15.4p1.exe) _b5fa0bc358bcfda90df8aae8ad97d8a5_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4p1/7kaa-2.15.4p1.tar.xz) _caa3c03c773de805c66546c2371a370c_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 

--- a/src/content/download/v2.13.0.md
+++ b/src/content/download/v2.13.0.md
@@ -6,8 +6,8 @@ order: 1
 Legacy Windows API version.
 
 - [All platforms 32-bit/64-bit GPL source code](https://www.7kfans.com/downloads/7kaa-2.13.2.tar.bz2) _1a626a2bf92f4ad394558a903f519594_
-- [Game data (only for 2.13.x) zip](https://www.7kfans.com/downloads/7kaa-data-2.13.zip')
-- [Game data (only for 2.13.x) tar.bz](https://www.7kfans.com/downloads/7kaa-data-2.13.tar.bz2')
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip')
+- [Game data (only for 2.13.x) zip](https://www.7kfans.com/downloads/7kaa-data-2.13.zip)
+- [Game data (only for 2.13.x) tar.bz](https://www.7kfans.com/downloads/7kaa-data-2.13.tar.bz2)
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music.tar.bz2)
-- [Windows 32-bit patch](https://www.7kfans.com/downloads/7kaa-patch-2.13.2.zip') _83152b21973c1b3df8de525bda434be4_
+- [Windows 32-bit patch](https://www.7kfans.com/downloads/7kaa-patch-2.13.2.zip) _83152b21973c1b3df8de525bda434be4_

--- a/src/content/download/v2.14.0.md
+++ b/src/content/download/v2.14.0.md
@@ -13,7 +13,7 @@ This said, the game might not be trouble free. Desync issues likely lurk still. 
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.7/7kaa-install-win32-2.14.7.exe) _6573ebb2a6689a83a52c86358a920316_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.7/7kaa-2.14.7.tar.xz) _f044d7bd57e636b8b9ac33b728581a43_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music.tar.bz2)
 - [Windows patch zip 2.15.0-dev](https://www.7kfans.com/downloads/7kaa-patch-2.15.0-dev-157c89d.zip)
 
@@ -27,9 +27,9 @@ This 2.14.xx series is now considered a stable branch of the tree for all users 
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.6/7kaa-install-win32-2.14.6.exe) _d5161b6bcae9c5cde605bf742f92eca2_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.6/7kaa-2.14.6.tar.xz) _a05a2fa0369946e45a427477f4e0c800_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music.tar.bz2)
-- [Windows exe-only](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.6/7kaa.exe') _68056ca8bb01484e915c8cae3161a951_
+- [Windows exe-only](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.6/7kaa.exe) _68056ca8bb01484e915c8cae3161a951_
 - [Windows patch zip 2.14.7-dev](https://www.7kfans.com/downloads/7kaa-patch-2.14.7-dev-9f2721f.zip)
 
 
@@ -55,6 +55,6 @@ Thanks to all who have contributed to this release.
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.5/7kaa-install-win32-2.14.5.exe) _38ee8b37558d9a111b9f1a1309a8ac2b_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.14.5/7kaa-2.14.5.tar.xz) _1a626a2bf92f4ad394558a903f519594_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music.tar.bz2)
-- [Windows exe-only](https://www.7kfans.com/downloads/7kaa-2.14.5-hotfix.exe') _83152b21973c1b3df8de525bda434be4_
+- [Windows exe-only](https://www.7kfans.com/downloads/7kaa-2.14.5-hotfix.exe) _83152b21973c1b3df8de525bda434be4_

--- a/src/content/download/v2.15.0.md
+++ b/src/content/download/v2.15.0.md
@@ -24,7 +24,7 @@ Allow copying trade routes using the trade report.
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4/7kaa-install-win32-2.15.4.exe) _b5fa0bc358bcfda90df8aae8ad97d8a5_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4/7kaa-2.15.4.tar.xz) _caa3c03c773de805c66546c2371a370c_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 
 
@@ -58,7 +58,7 @@ Correct replay initialization for weather sync.
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.3/7kaa-install-win32-2.15.3.exe) _dfc408696a80a73903c3d8dad165d213_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4p1/7kaa-2.15.4p1.tar.xz) _57a65e4352df60449429c698f34c8b76_
-- [Music (Not GPL) zip](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.3/7kaa-2.15.3.tar.xz')
+- [Music (Not GPL) zip](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.3/7kaa-2.15.3.tar.xz)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 
 
@@ -83,7 +83,7 @@ Enabled sync checking in replay mode.
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.2/7kaa-install-win32-2.15.2.exe) _e9d62d46ac55d97c5574ed70766d65ed_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.2/7kaa-2.15.2.tar.xz) _abd3648aec3b8337a16f22de43ce9b19_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 - [Windows patch zip 2.15.3-dev](https://www.7kfans.com/downloads/7kaa-patch-2.15.3-dev-00c6ac9.zip) 
 
@@ -119,7 +119,7 @@ the latest download for the music.
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.1/7kaa-install-win32-2.15.1.exe) _3e15530028edf84418ddbc5b28d01731_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.1/7kaa-2.15.1.tar.xz) _977894288ec7bde8235ebd500d82c6f2_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 
 
@@ -149,7 +149,7 @@ Thanks to all who made this release possible.
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.0/7kaa-install-win32-2.15.0.exe) _297ffc314d4beec2aabc4937127a058f_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.0/7kaa-2.15.0.tar.xz) _4478e7aaa3fd5e5104697f1cd7017c47_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 
 

--- a/src/content/latest.md
+++ b/src/content/latest.md
@@ -7,7 +7,7 @@ This is a patch release to fix a few issues with 2.15.4. All users should upgrad
 
 - [Windows 32-bit installer](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4p1/7kaa-install-win32-2.15.4p1.exe) _b5fa0bc358bcfda90df8aae8ad97d8a5_
 - [All platforms 32-bit/64-bit GPL source code](https://github.com/the3dfxdude/7kaa/releases/download/v2.15.4p1/7kaa-2.15.4p1.tar.xz) _caa3c03c773de805c66546c2371a370c_
-- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip')
+- [Music (Not GPL) zip](https://www.7kfans.com/downloads/7kaa-music-2.15.zip)
 - [Music (Not GPL) tar.bz](https://www.7kfans.com/downloads/7kaa-music-2.15.tar.bz2)
 
 


### PR DESCRIPTION
Some of the download links on the current site are broken because of a trailing `'` in the URLs.